### PR TITLE
Document append-only Liquibase migration policy

### DIFF
--- a/case-management-core/src/main/resources/db/changelog/cm-poc-additions.xml
+++ b/case-management-core/src/main/resources/db/changelog/cm-poc-additions.xml
@@ -7,6 +7,12 @@
   <!-- PoC-ONLY additions (spec §3.5). These are NOT part of the target design:
        they exist because remote mode cannot join the local transaction. -->
 
+  <!-- Migration ordering policy: treat this file as append-only once a changeset may have
+       been applied by a developer, CI database, or shared environment. Liquibase identifies
+       changesets by file, id, and author, but this file also serves as an execution timeline.
+       Add corrective changesets at the end with a rationale; do not move existing changesets
+       purely to improve topical grouping. -->
+
   <changeSet id="cm-poc-engine-command" author="casemgmt">
     <createTable tableName="CM_ENGINE_COMMAND">
       <column name="ID_" type="VARCHAR2(64)"><constraints primaryKey="true" nullable="false"/></column>

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -291,6 +291,11 @@ Schema source of truth: [`db-design.sql`](../db-design.sql), executed by an appl
 changeset and **never re-typed**. PoC-only additions go in `cm-poc-additions.xml`; an applied
 changeset is never edited.
 
+Treat changelog files as append-only once a changeset may have run in a developer, CI or shared
+environment. New corrections are added as new changesets at the end of the relevant file with a
+short rationale comment. Existing changesets are not moved merely to group related columns or tables
+together, because the changelog is also the execution timeline.
+
 **Access pattern:** Spring `JdbcClient`, no ORM. One repository per aggregate.
 
 ### 9.1 Tables with a code path


### PR DESCRIPTION
## Summary
- Document that cm-poc-additions.xml is append-only once a changeset may have run in developer, CI, or shared environments.
- Clarify that existing Liquibase changesets should not be moved purely for topical grouping.
- Add the same migration hygiene rule to the persistence section of the system overview.

## Verification
- xmllint --noout case-management-core/src/main/resources/db/changelog/cm-poc-additions.xml
- git diff --check

Closes #50