### PR TITLE
docs: define declarative case experience and search model

### DIFF
--- a/docs/declarative-case-model-architecture.md
+++ b/docs/declarative-case-model-architecture.md
@@ -1,0 +1,517 @@
+# Declarative Case Model Architecture
+
+Status: target architecture for discussion. This document does not describe the case-definition
+format currently accepted by the runtime.
+
+## Purpose
+
+The declarative case model is the versioned source from which case behavior, data validation,
+authorization bindings, search capabilities, presentation descriptors, projection plans, contracts,
+and conformance tests are derived. It must be precise enough for independent implementations and
+automation while remaining understandable to domain teams.
+
+The source of truth is a **model bundle**, not one ever-growing YAML document. The bundle manifest
+binds immutable, independently owned artifacts into one deployable case-type version.
+
+## Design principles
+
+| Principle | Requirement |
+|---|---|
+| One field source | Data shape, type, stable field id, classification, ownership, and maximum permitted use are defined once. |
+| Stable public identity | APIs, UI, search, events, and policies refer to stable ids rather than storage columns or mutable JSON paths. |
+| Intent before technology | The model describes query and presentation semantics; a compiler produces Oracle or other backend plans. |
+| Policy by construction | Read, write, match, disclose, count, suggest, highlight, and semantic-use decisions are explicit and fail closed. |
+| Immutable publication | Published bundle artifacts are content-addressed and cannot change in place. |
+| Independent compatibility | Data, behavior, events, search, views, policy, and physical indexes have separate impact classifications. |
+| Rebuildable discovery | Search indexes and projections are replaceable read models with provenance, lag, and rebuild contracts. |
+| Host neutrality | A case model declares required frontend capabilities, never a named portal, route, token source, or theme implementation. |
+| Bounded extension | Custom fields, components, composers, and providers use versioned registries and validated contracts. |
+
+## Bundle architecture
+
+```mermaid
+flowchart LR
+  manifest["Case model bundle manifest"]
+
+  subgraph normative["Normative model artifacts"]
+    data["Data schema + normalized field catalog"]
+    behavior["Commands + lifecycle + tasks"]
+    policies["Authorization + compliance policies"]
+    events["Event contracts"]
+    projections["Projection definitions"]
+    search["Search parameters + profiles + relationships"]
+    views["Forms + view manifests"]
+  end
+
+  subgraph evidence["Delivery evidence"]
+    tests["Conformance scenarios"]
+    operations["Operational profile references"]
+  end
+
+  manifest --> data
+  manifest --> behavior
+  manifest --> policies
+  manifest --> events
+  manifest --> projections
+  manifest --> search
+  manifest --> views
+  manifest --> tests
+  manifest --> operations
+
+  compiler["Model validator and compiler"]
+  data --> compiler
+  behavior --> compiler
+  policies --> compiler
+  events --> compiler
+  projections --> compiler
+  search --> compiler
+  views --> compiler
+  tests --> compiler
+
+  compiler --> runtime["Runtime definition"]
+  compiler --> contracts["OpenAPI + AsyncAPI + typed clients"]
+  compiler --> physical["Projection and index plans"]
+  compiler --> descriptors["View + Search descriptors"]
+  compiler --> generatedTests["Generated conformance tests"]
+  compiler --> docs["Reference documentation"]
+```
+
+## Suggested bundle layout
+
+```text
+case-models/widget-review/7/
+  case-model.yaml
+  schemas/case-data.schema.json
+  behavior/commands.yaml
+  behavior/lifecycle.yaml
+  behavior/tasks.yaml
+  policies/authorization.yaml
+  policies/compliance.yaml
+  contracts/events.asyncapi.yaml
+  read-models/projections.yaml
+  discovery/search.yaml
+  experience/views.yaml
+  experience/forms/
+  tests/conformance.yaml
+```
+
+The directory layout is an authoring convention. The deployable unit is a manifest plus immutable
+artifact references and digests. Implementations may package it as an archive, registry object, or
+signed release artifact without changing its logical contract.
+
+```yaml
+apiVersion: case-management.platform/v1alpha1
+kind: CaseModelBundle
+metadata:
+  id: widget-review
+  version: 7.0.0
+  status: draft
+  owner: widget-domain
+compatibility:
+  platform: ">=2.0 <3.0"
+artifacts:
+  data: schemas/case-data.schema.json
+  commands: behavior/commands.yaml
+  lifecycle: behavior/lifecycle.yaml
+  tasks: behavior/tasks.yaml
+  authorization: policies/authorization.yaml
+  compliance: policies/compliance.yaml
+  events: contracts/events.asyncapi.yaml
+  projections: read-models/projections.yaml
+  search: discovery/search.yaml
+  views: experience/views.yaml
+  tests: tests/conformance.yaml
+requirements:
+  hostCapabilities: [navigation, notifications, file-upload, design-tokens]
+  platformCapabilities: [worker-permissions, document-references, outbox]
+```
+
+## Canonical data and field catalog
+
+`schemas/case-data.schema.json` is the only definition of case-variable structure and validation.
+It uses JSON Schema 2020-12, `$defs`, `$ref`, and `unevaluatedProperties: false` where closed objects
+are required. Forms reference schema fragments; they do not copy field schemas into form or UI
+metadata.
+
+The platform defines a required JSON Schema vocabulary for field-governance annotations. A validator
+that does not understand the required vocabulary must reject the model rather than ignore security-
+relevant annotations. The compiler normalizes these annotations into a field catalog for downstream
+validation and tooling; that catalog is generated evidence, not a second authoring source.
+
+Each governed field has a stable id that survives path changes. The normalized catalog maps the
+stable id to the current JSON Pointer and defines the maximum uses any downstream profile may
+request. The following YAML illustrates the compiler output, not an additional bundle artifact.
+
+```yaml
+fields:
+  customer-id:
+    pointer: /customer/id
+    schemaRef: "schemas/case-data.schema.json#/$defs/customerId"
+    owner: customer-domain
+    classification: confidential
+    purpose: case-handling
+    policyRef: customer-identifier-policy
+    mutability: create-only
+    audit: value-changed
+    discovery:
+      queryModes: [exact]
+      filterable: true
+      sortable: false
+      facetable: false
+      suggestible: false
+      highlightable: false
+      resultDisclosure: masked
+      semanticIndexing: forbidden
+      matchRequiresRead: true
+
+  decision-reason:
+    pointer: /decision/reason
+    schemaRef: "schemas/case-data.schema.json#/$defs/decisionReason"
+    owner: widget-domain
+    classification: confidential
+    purpose: case-decision
+    policyRef: decision-reason-policy
+    mutability: task-output
+    discovery:
+      queryModes: [full-text]
+      filterable: false
+      sortable: false
+      facetable: false
+      suggestible: false
+      highlightable: policy-controlled
+      resultDisclosure: policy-controlled
+      semanticIndexing: approval-required
+      matchRequiresRead: true
+```
+
+Field-level discovery metadata is a **ceiling**, not an instruction to build an index. Search
+profiles can select a permitted subset; they cannot enable a capability forbidden by the field.
+
+Canonical field rules:
+
+- Field ids are lowercase kebab-case, unique within the bundle namespace, and never reused.
+- JSON Pointers are version-specific implementation details and are not public API parameter names.
+- Nested objects and arrays define matching, replacement, and masking semantics explicitly.
+- Read and write policies are distinct; discovery never implies write access.
+- Classification, ownership, purpose, retention, and policy are not repeated in UI or search files.
+- Derived fields declare source lineage, transformation version, freshness, and rebuild behavior.
+- External fields declare a provider and are never silently persisted into authoritative case data.
+
+## Commands and behavior
+
+Commands are first-class contracts rather than UI buttons or state-transition labels. They bind
+input, authorization, concurrency, idempotency, effects, and emitted events.
+
+```yaml
+commands:
+  approve-review:
+    inputSchemaRef: "schemas/case-data.schema.json#/$defs/approvalInput"
+    allowedStates: [in-review]
+    authorizationPolicy: approve-review-policy
+    concurrency: if-match-required
+    idempotency: required
+    effects:
+      state: approved
+      writes: [decision-reason]
+    emits: [case-approved-v1]
+```
+
+Lifecycle, tasks, forms, available actions, and view descriptors reference the command id. The
+server recomputes availability and authorizes every command at execution time.
+
+## Search parameters and profiles
+
+A boolean `searchable` field is insufficient. Search is decomposed into stable parameters and
+context-specific profiles:
+
+| Capability | Meaning |
+|---|---|
+| Query mode | Exact, prefix, contains, full-text, range, reference, relationship, or semantic matching. |
+| Filter | Structured inclusion or exclusion using typed operators. |
+| Sort | Use as an ordering key with defined null and collation behavior. |
+| Facet | Return values and counts; may require suppression thresholds. |
+| Suggest | Expose values through typeahead; often forbidden for confidential identifiers. |
+| Highlight | Return a matched fragment after authorization and masking. |
+| Result disclosure | Return raw, masked, derived, or no value in a result. |
+| Semantic use | Embed, retrieve, summarize, or prohibit use in an AI-assisted flow. |
+
+Search parameters have stable ids independent of current field paths. Profiles select parameters,
+providers, ranking, result views, and availability behavior for one search experience.
+
+```yaml
+searchParameters:
+  customer:
+    version: 1
+    source:
+      field: customer-id
+    type: token
+    operators: [eq, in]
+    aliases: [customerId]
+    provider: case-summary
+    materializationHint: tokenized-exact
+
+  decision-text:
+    version: 1
+    source:
+      field: decision-reason
+    type: text
+    operators: [full-text]
+    provider: case-content
+
+searchProfiles:
+  case-workbench:
+    version: 1
+    scopes: [cases]
+    parameters: [case-id, business-key, customer, state, updated-at, decision-text]
+    defaultSort: updated-at-desc
+    pagination: cursor
+    rankingProfile: operational-cases-v1
+    resultView: case-search-result-v1
+    authorizationPolicy: case-search-policy
+    availability:
+      partialResults: allowed-with-warning
+      essentialProviders: [case-summary]
+```
+
+The same parameter can map to `/customerId` in an older case-data version and `/customer/id` in a
+newer version. Aliases support controlled API migration, but retired ids remain reserved.
+
+Search parameters may source values from:
+
+- Canonical case fields.
+- Platform case, task, SLA, participant, and document metadata.
+- Rebuildable derived fields with recorded lineage.
+- Relationship edges.
+- Approved external providers.
+- Extracted document content in a separate governed projection.
+
+## Relationships and discovery
+
+Search should support discovery, not only text matching. Relationships are versioned model elements
+used for related-case navigation, duplicate detection, evidence discovery, and controlled expansion.
+
+```yaml
+relationships:
+  same-customer:
+    from: case
+    to: case
+    joinParameters: [customer]
+    direction: symmetric
+    authorization: both-resources-visible
+    uses: [related-cases, duplicate-candidate]
+    maximumExpansion: 50
+```
+
+A relationship result is not authority to access the target. Both endpoints and every disclosed
+edge attribute pass the same resource and field projection used by ordinary reads.
+
+## Search authorization contract
+
+Search policy distinguishes operations that are commonly conflated:
+
+- **Discover:** may the caller learn that a resource or parameter exists?
+- **Match:** may a query use the field to select a resource?
+- **Disclose:** may the field value be returned in a result?
+- **Highlight:** may a matched fragment be returned?
+- **Aggregate:** may values and counts be used in facets or analytics?
+- **Suggest:** may values appear before a full search is executed?
+- **Export:** may the value leave the interactive search response?
+- **Semantic:** may the value be embedded, retrieved, or supplied to an AI-assisted flow?
+
+The default is that matching requires read permission. Any exception requires a named policy,
+purpose, threat analysis, and negative leakage tests. Missing field decisions deny every operation;
+unrestricted access requires an explicit wildcard decision.
+
+For highly sensitive identifiers, an approved provider may materialize a keyed token for exact
+matching. The plaintext value is not placed in the search projection, and the field remains
+ineligible for prefix, full-text, suggestion, facet, and highlight operations. Key management,
+rotation, collision handling, and reindexing are part of the provider's operating contract.
+
+## Permission-aware Search Descriptor
+
+The server compiles a Search Descriptor from the active profile, provider capabilities, current
+field policies, and caller context. It returns only parameters and operations the caller may use.
+Lit renderers use it to build filters, facets, result columns, sort menus, and related-discovery
+controls without interpreting authorization rules.
+
+```json
+{
+  "descriptorVersion": "1.0",
+  "profile": "case-workbench",
+  "parameters": [
+    { "id": "state", "type": "token", "operators": ["eq", "in"], "facetable": true },
+    { "id": "customer", "type": "token", "operators": ["eq"],
+      "facetable": false, "suggestible": false, "resultDisclosure": "masked" }
+  ],
+  "sorts": ["updated-at-desc"],
+  "resultView": "case-search-result-v1",
+  "pagination": "cursor"
+}
+```
+
+The target API adds `GET /search/capabilities?profile={id}` or an equivalent view-composer resource.
+It is a target contract, not an endpoint implemented by the current repository. Descriptors are
+caller-specific and initially use `Cache-Control: private, no-store`; later validators must include
+the profile, provider, model, locale, and authorization-policy revisions.
+
+Search requests use stable parameter ids and a typed expression tree rather than an arbitrary map
+of backend-specific filters:
+
+```json
+{
+  "profile": "case-workbench",
+  "text": "late review",
+  "where": {
+    "all": [
+      { "parameter": "state", "operator": "in", "value": ["open", "in-review"] },
+      { "parameter": "customer", "operator": "eq", "value": "customer-42" }
+    ]
+  },
+  "sort": ["updated-at-desc"],
+  "cursor": null,
+  "limit": 25
+}
+```
+
+The query compiler rejects undeclared parameters, unsupported operators, type mismatches, and
+unauthorized operations before invoking a provider. Result metadata uses authorized parameter ids,
+not raw JSON paths. Total counts may be omitted, rounded, or suppressed when expensive or sensitive.
+
+## Projection and physical index planning
+
+Search semantics stay vendor-neutral. A compiler combines parameter operations, data shape,
+cardinality hints, provider capabilities, and the deployment profile to generate a reviewable
+physical plan.
+
+For the Oracle deployment profile, likely strategies include:
+
+| Search need | Candidate physical strategy |
+|---|---|
+| Exact or range query on selected scalar fields | Relational projection column with B-tree or function-based index. |
+| Repeated scalar values in arrays | Multivalue JSON index or normalized child projection. |
+| Approved ad-hoc structural and full-text JSON queries | JSON search index or Oracle Text projection. |
+| Heavy cross-domain relevance and aggregation | Optional external search projection, justified separately. |
+
+Physical index names, DDL, analyzer configuration, partitioning, and backend aliases are generated
+deployment artifacts. They do not appear in the domain-authored model.
+
+Every projection mapping declares source events or authoritative snapshot source, key, transformation
+version, tombstone handling, idempotency, checkpoint, rebuild procedure, provenance, and maximum lag.
+
+## Activation lifecycle
+
+Publishing a model does not make a new search profile immediately queryable. Activation waits for
+policy approval, materialization, backfill, parity tests, and an atomic alias or registry switch.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Validated: schema + reference validation
+  Validated --> Approved: policy + ownership approval
+  Approved --> Materializing: build shadow projection/index
+  Materializing --> Verifying: backfill complete
+  Verifying --> Active: parity + authorization tests pass
+  Materializing --> Failed: build or backfill failure
+  Verifying --> Failed: parity or security failure
+  Failed --> Materializing: corrected retry
+  Active --> Retired: replacement activated
+  Active --> RollingBack: production validation failure
+  RollingBack --> Active: previous alias restored
+  Retired --> [*]
+```
+
+Activation requirements:
+
+- Existing active profile remains available while a shadow version builds.
+- Backfill and replay are idempotent and multi-instance safe.
+- Parity tests compare expected resources, ordering, masking, facets, and deletion behavior.
+- Permission changes are tested independently from data and index changes.
+- Rollback restores the previous descriptor and physical alias without rewriting case instances.
+- Privacy deletion, retention expiry, and document removal propagate to every derived index.
+
+## Versioning and impact analysis
+
+Semantic versioning alone cannot describe operational impact. The compiler produces an impact report
+for each bundle change:
+
+| Impact axis | Examples |
+|---|---|
+| Data | Required field, type change, path move, default, migration. |
+| Behavior | Command, transition, task, timer, criterion, decision. |
+| Contract | API input/output, event schema, search parameter, descriptor primitive. |
+| Policy | Read/write/discovery policy or classification change. |
+| Projection | Mapping, source event, rebuild, tombstone, lag objective. |
+| Physical index | New index, backfill, analyzer/tokenization change, alias switch. |
+| Experience | View, form, label, accessibility, or component contract. |
+
+A path move with an unchanged stable field id may be API-compatible but still require data migration
+and reindexing. Enabling facets on an existing field may be a non-breaking query-contract change but
+still require policy approval, physical materialization, and leakage tests.
+
+## Experience integration
+
+The UI model references canonical field ids, command ids, view ids, and search profile ids. It never
+defines another data schema or grants field access.
+
+The server-composed View API may include a `search` primitive that references an authorized Search
+Descriptor. Typical uses include a global workbench, a related-cases section, a document evidence
+picker, and a reference-data selector. The same descriptor works in standalone and embedded Lit
+renderers; host adapters supply only normalized shell capabilities.
+
+## Validation and generated evidence
+
+Model validation runs before publication and includes:
+
+- JSON Schema validation for every artifact.
+- Digest and immutable-reference verification.
+- Stable-id uniqueness, reserved-id, alias, and deprecation checks.
+- Cross-reference checks across fields, commands, events, projections, search, views, and tests.
+- Static criterion and transformation symbol validation.
+- Policy checks that downstream capabilities never exceed field ceilings.
+- Search operator/type compatibility and provider capability checks.
+- Projection rebuild completeness, deletion, tombstone, and source-event checks.
+- Host-capability compatibility without named-host configuration in the model.
+
+Generated conformance evidence includes positive and negative command tests, field read/write tests,
+search match/disclose/facet/suggestion/highlight tests, descriptor masking tests, projection replay,
+schema-evolution fixtures, accessibility checks, and model-to-artifact traceability.
+
+## Current implementation boundary
+
+The repository currently accepts one JSON definition containing roles, forms, attachment categories,
+and plan items. Case variables are an untyped map, search providers are registered in code, and the
+Lit shell does not interpret case-type views. None of the bundle, field catalog, search parameter,
+Search Descriptor, or compilation contracts above is implemented yet.
+
+Recommended delivery order:
+
+1. Publish the bundle meta-schema, field vocabulary, normalized catalog contract, reference rules,
+   and validator without changing
+   runtime behavior.
+2. Introduce the canonical case-data schema and validate variables, form references, criteria, and
+   command input/output against stable field ids.
+3. Compile search parameters and profiles into provider registrations, projection plans, typed query
+   validation, and permission-aware Search Descriptors.
+4. Implement governed projection activation, backfill, parity, rollback, and privacy propagation.
+5. Add the server-composed View API and Lit renderer over the same canonical field and policy model.
+6. Add relationships and optional semantic discovery only after the structured path is proven.
+
+## Acceptance criteria
+
+- A case type is published as an immutable bundle validated by a machine-readable meta-schema.
+- Data, UI, search, events, permissions, and tests reference one canonical stable field catalog.
+- No field becomes matchable, disclosable, facetable, suggestible, highlightable, or embeddable through
+  a boolean shortcut or an implicit provider default.
+- A caller receives only authorized Search Descriptor parameters and operations.
+- Search requests reject unknown or unauthorized parameters before provider execution.
+- Search profile changes activate only after backfill, parity, and negative authorization tests pass.
+- Existing case and search versions remain resolvable during migration and rollback.
+- Named portal configuration is absent from the case model; only required host capabilities remain.
+
+## Primary references
+
+- [JSON Schema 2020-12 specification](https://json-schema.org/specification)
+- [JSON Schema custom vocabularies](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-00#section-6.5)
+- [HL7 FHIR SearchParameter](https://hl7.org/fhir/searchparameter.html)
+- [OData Capabilities Vocabulary](https://docs.oasis-open.org/odata/odata-vocabularies/v4.0/odata-vocabularies-v4.0.html)
+- [Oracle JSON indexing guidance](https://docs.oracle.com/en/database/oracle/oracle-database/26/adjsn/overview-performance-tuning-json.html)

--- a/docs/declarative-case-ui-proposal.md
+++ b/docs/declarative-case-ui-proposal.md
@@ -4,9 +4,13 @@ We already have a declarative *behavioral* case model. This document maps the ga
 *presentation* model — where the front-end renders most case logic from the model, with pro-code
 escape hatches — surveys how five competitors solved it, and puts forward three architectures.
 
-Status: for discussion. Revision 3 (security, contract, caching, extension-governance, and
-operability requirements added after architecture review; vendor-neutral portal integration from
-PR #86 / commit `1a51cea` retained).
+The target authoring structure, canonical field model, search profiles and artifact boundaries are
+defined in [`declarative-case-model-architecture.md`](declarative-case-model-architecture.md). The UI
+manifest is one artifact in that bundle; it is not another source of data or authorization truth.
+
+Status: for discussion. Revision 4 (composable model bundle, canonical field vocabulary,
+permission-aware search contracts, generated projection plans, and prior security, portal,
+extension-governance, caching, and operability requirements incorporated).
 
 ## What we have today — and what "declarative" currently stops at
 
@@ -67,6 +71,10 @@ are three defensible positions on that axis.
   keys, and semantic formatting hints rather than preformatted web strings.
 - **Governed extension model:** custom components and composers are trusted, registered deployment
   units with bounded capabilities, versioned contracts, and observable failure behavior.
+- **One canonical field model:** forms, views, search, events, projections and policies reference
+  stable field ids from the case-data catalog instead of copying types, paths or classifications.
+- **Descriptor-driven discovery:** search and related-resource controls render from a caller-specific
+  Search Descriptor compiled by the server from search profiles and field policy.
 
 The three proposals differ in exactly one thing: *where* the case model, live instance state, and
 worker permissions are composed into a renderable UI — in the client (A), in the server per request
@@ -93,24 +101,31 @@ flowchart LR
 **Thesis:** extend the case definition with a presentation section; the Lit shell becomes a generic
 interpreter of it.
 
-The definition JSON (or a versioned sibling artifact deployed with it) gains a `ui` section: a
-typed data schema for `vars`, a summary layout, detail sections, worklist columns, per-form
-uiSchema, and action placement. The shell stops being two hand-coded panels and becomes one
-renderer that walks the manifest, calls the existing REST API for state, and honors
+The model bundle gains a view-manifest artifact containing summary layout, detail sections, worklist
+columns, per-form `uiSchema`, search-profile placement and action placement. The canonical case-data
+schema remains a separate bundle artifact; its governance annotations compile into the shared field
+catalog used by UI, search, policy, and contract tooling. The shell stops being two hand-coded panels
+and becomes one renderer that walks the manifest, calls the existing REST API for state, and honors
 `AvailableAction` for every button it draws.
 
 ```json
 {
+  "data": {
+    "schemaRef": "schemas/case-data.schema.json"
+  },
   "ui": {
-    "dataSchema": { "amount": {"type":"number","format":"currency"},
-                    "customerId": {"type":"string","label":"Customer"} },
-    "summary":   { "fields": ["businessKey","state","amount","slaStatus"] },
+    "summary":   { "fields": ["system:business-key", "system:state",
+                                 "field:amount", "system:sla-status"] },
     "sections": [
       { "id":"work",  "title":"Work",     "component":"plan-tree" },
       { "id":"docs",  "title":"Documents","component":"document-list" },
-      { "id":"risk",  "title":"Risk",     "component":"risk-panel" }
+      { "id":"risk",  "title":"Risk",     "component":"risk-panel" },
+      { "id":"related", "title":"Related cases", "component":"search",
+        "searchProfile":"related-cases" }
     ],
-    "worklist":  { "columns": ["businessKey","title","assignee","slaStatus"] },
+    "worklist":  { "searchProfile":"case-workbench",
+                    "columns": ["system:business-key", "system:title",
+                                "system:assignee", "system:sla-status"] },
     "forms":     { "reviewForm": { "uiSchema": { "note": {"widget":"textarea"} } } }
   }
 }
@@ -176,6 +191,14 @@ may be introduced only after the centralized authorization prerequisite below is
       "slaStatus": "WARNING"
     },
     "planItems": ["..."],
+    "searchDescriptors": {
+      "related-cases": {
+        "profile": "related-cases",
+        "parameters": ["relationship", "state"],
+        "sorts": ["updated-at-desc"],
+        "pagination": "cursor"
+      }
+    },
     "actions": [
       { "id": "start-review", "action": "start", "href": "...", "method": "POST" }
     ]
@@ -193,6 +216,7 @@ may be introduced only after the centralized authorization prerequisite below is
       ] },
       { "type": "planTree", "itemsBind": "/data/planItems",
         "actionRefs": ["start-review"] },
+      { "type": "search", "descriptorBind": "/data/searchDescriptors/related-cases" },
       { "type": "extension", "componentId": "risk-panel",
         "contractVersion": "1", "props": { "caseId": "case-42" } }
     ]
@@ -270,6 +294,28 @@ validation linkage, accessible names, responsive behavior, and design-token hook
 reject unsupported major versions predictably and show an auditable compatibility error rather than
 silently dropping required content.
 
+### Search and discovery integration
+
+Search is a first-class view primitive backed by the declarative model's versioned search profiles.
+The UI manifest chooses a profile and placement; it does not list database fields, operators, facets,
+providers, or authorization rules.
+
+For each caller, the server compiles a Search Descriptor from the active profile, canonical field
+catalog, provider capabilities, and Worker Permissions decisions. The descriptor exposes only the
+parameters, operators, facets, sorts, result fields, and relationship expansions the caller may use.
+The same descriptor drives a global workbench, related-cases section, document evidence picker, or
+reference-data selector in standalone and embedded hosts.
+
+Search requests use stable parameter ids and a typed expression tree. Raw JSON paths and arbitrary
+provider-specific filter maps are not public contracts. Search results pass through centralized
+resource and field projection before being attached to a view; matched-field metadata, highlights,
+facets, suggestions, and counts follow the same disclosure rules as ordinary search responses.
+
+The Search Descriptor is caller-specific and initially non-cacheable. A future validator includes
+the search-profile, provider, model, locale, and authorization-policy revisions. Detailed model,
+activation, and projection requirements are defined in
+[`declarative-case-model-architecture.md`](declarative-case-model-architecture.md).
+
 ### Strengths
 
 - Once the authorization prerequisite is complete, permissions and masking are enforced once,
@@ -303,7 +349,7 @@ app is a starting point the team edits; regeneration flows through git as an ord
 
 ```text
 $ casemgmt generate --definition widget-review@7 --out apps/widget-review
-  ✓ types/WidgetReviewVars.ts        # from ui.dataSchema
+  ✓ types/WidgetReviewVars.ts        # from the canonical case-data schema
   ✓ forms/ReviewForm.ts              # from forms.reviewForm JSON Schema
   ✓ pages/case-page.ts, worklist.ts  # composed from @casemgmt/sdk primitives
   → edit anything; `generate --update` merges model changes as a git diff
@@ -346,14 +392,14 @@ UI, OutSystems-style scaffolding.
 
 ## Recommendation
 
-**Take B as the destination, A as the authoring format, and the component registry as the shared
-escape hatch.** The manifest of Proposal A becomes the *input* the Proposal B composer consumes —
-authored at design time, versioned with the definition, but merged with state and permissions on
-the server. `AvailableAction` already provides a strong runtime contract. Worker Permissions provides
-the authorization foundation, but field projection must first become centralized, fail closed, and
-complete across all response types. Proposal C's headless SDK is worth building regardless (the thin
-renderer needs it anyway), but as an integration option for teams that opt out — not the platform's
-main path.
+**Take B as the destination, A's view manifest as an artifact in the model bundle, and the component
+registry as the shared escape hatch.** The view manifest becomes one input the Proposal B composer
+consumes alongside the canonical data schema, field catalog, commands, search profiles, state, and
+permissions. `AvailableAction` already provides a strong runtime contract. Worker Permissions
+provides the authorization foundation, but field projection must first become centralized, fail
+closed, and complete across all response types. Proposal C's headless SDK is worth building
+regardless (the thin renderer needs it anyway), but as an integration option for teams that opt out —
+not the platform's main path.
 
 This is deliberately the Pega-shaped answer with a ServiceNow-shaped authoring story. For a regulated
 platform, the decisive property is that *a field a worker may not see never reaches the browser*.
@@ -362,9 +408,9 @@ inside the same projection boundary.
 
 | Phase | Scope |
 |---|---|
-| 0 | Define canonical field paths and read/write semantics; make missing or empty field decisions deny by default; implement one central projection service across case, task, document, collaboration, search, and error DTOs; add negative authorization conformance tests before exposing a composed view. |
-| 1 | Define and publish JSON Schemas for the versioned `ui` authoring manifest and runtime descriptor; add typed `dataSchema` for `vars`; separately validate criterion expressions against declared variable and plan-item symbols at deploy time. |
-| 2 | Implement the orchestrated composer service and `/view` endpoints with canonical data separated from presentation bindings; reauthorize every action at execution; publish OpenAPI and start with `Cache-Control: private, no-store`. |
+| 0 | Publish the model-bundle meta-schema, canonical case-data schema and stable field vocabulary; define read/write/discovery semantics; make missing or empty field decisions deny by default; implement one central projection service across case, task, document, collaboration, search, view, and error DTOs. |
+| 1 | Publish JSON Schemas for the view manifest, View Descriptor, search parameters, search profiles, and Search Descriptor; statically validate field, command, criterion, projection, search, and view references; generate negative authorization conformance fixtures. |
+| 2 | Implement the orchestrated composer and search-capability services, `/view` and Search Descriptor endpoints, typed search expressions, generated projection plans, and governed shadow-index activation; reauthorize every action at execution and start caller-specific descriptors with `Cache-Control: private, no-store`. |
 | 3 | Replace the hand-coded Lit panels with a thin renderer for the bounded primitive vocabulary; implement localization, accessibility, responsive behavior, design-token mapping, unsupported-version handling, and embedded/standalone conformance tests. |
 | 4 | Add the allowlisted, versioned component registry and bounded `ViewComposer` SPI; implement schema validation, timeout and failure isolation, tracing, post-composition projection, and security tests for extension output. Export and document the normalized host contract for platform integration, while custom components receive only a scoped capability facade. |
 | 5 | Extract the headless `@casemgmt/sdk` from the renderer for opt-out teams; add optional code generation only if adoption evidence justifies its lifecycle and migration cost. |
@@ -385,6 +431,9 @@ The following decisions must be recorded before implementation starts:
 - **Availability behavior:** classify core and optional composers, define page-level latency and
   availability objectives, and agree which failures produce a partial view versus a fail-closed
   response.
+- **Search contract:** confirm stable parameter naming, typed operators, cursor semantics, sensitive-
+  identifier handling, profile approval, shadow-index activation, and whether Search Descriptors are
+  served directly or embedded in composed views.
 
 ## Vendor-neutral portal reassessment
 
@@ -416,8 +465,7 @@ over community or third-party architecture summaries.
   [Custom components](https://www.servicenow.com/docs/r/application-development/ui-builder/component-builder.html)
 - Appian — [Case Management Studio overview](https://docs.appian.com/suite/help/25.4/case-management-studio-overview.html) ·
   [Low-code configurations](https://docs.appian.com/suite/help/24.3/cms-low-code-configurations.html)
-- Salesforce — [OmniStudio FlexCards](https://trailhead.salesforce.com/content/learn/modules/omnistudio-flexcard-fundamentals/get-to-know-omnistudio-flexcards) ·
-  [FlexCard component reference](https://developer.salesforce.com/docs/platform/lightning-component-reference/guide/lightning-omnistudio-flexcard.html)
+- Salesforce — [OmniStudio FlexCards](https://trailhead.salesforce.com/content/learn/modules/omnistudio-flexcard-fundamentals/get-to-know-omnistudio-flexcards)
 - Flowable — [Case Views](https://documentation.flowable.com/latest/reactmodel/cmmn/concept/case-view) ·
   [CMMN solution](https://www.flowable.com/solutions/cmmn)
 - Backbase — [Micro-frontends at Backbase](https://engineering.backbase.com/2024/05/15/maintaining-legacy-code-with-micro-frontends/)

--- a/docs/declarative-case-ui-proposal.md
+++ b/docs/declarative-case-ui-proposal.md
@@ -4,8 +4,9 @@ We already have a declarative *behavioral* case model. This document maps the ga
 *presentation* model — where the front-end renders most case logic from the model, with pro-code
 escape hatches — surveys how five competitors solved it, and puts forward three architectures.
 
-Status: for discussion. Revision 2 (reassessed against the vendor-neutral portal integration in
-PR #86 / commit `1a51cea`).
+Status: for discussion. Revision 3 (security, contract, caching, extension-governance, and
+operability requirements added after architecture review; vendor-neutral portal integration from
+PR #86 / commit `1a51cea` retained).
 
 ## What we have today — and what "declarative" currently stops at
 
@@ -19,16 +20,17 @@ web-components shell hand-codes two generic panels and knows nothing about any p
 | Work model | Yes | Plan items: stages, human tasks, milestones, process tasks; entry/exit criteria (sandboxed JUEL); required / manual-activation / repetition semantics |
 | Form validation | Yes | JSON Schema per `formKey`, enforced server-side on task completion (422 with RFC 6901 pointers) |
 | Actions | Yes (runtime) | `AvailableAction`: server computes `action / name / href / method / formKey` per resource — a renderer never guesses what a caller may do |
-| Authorization | Yes (runtime) | Worker-permission evaluator with per-field masking, already applied inside search providers |
+| Authorization | Partial (runtime) | Worker-permission evaluator provides resource and field decisions. Search and collaboration responses apply local masking, but ordinary case responses still expose the complete `variables` map and there is no central field-projection service yet |
 | Form rendering | No | Schema validates payloads; nothing renders it. No uiSchema, no widget hints, no layout |
 | Case data model | No | `vars` is an untyped bag; criteria reference it blind, the UI can't render what it can't name |
 | Views & layout | No | No summary panel model, no tabs/sections, no worklist column config, no per-type theming or labels |
 | Front-end | No | Hand-coded Lit shell (generic case list + task list) behind `PortalAdapter` — one vendor-neutral embedded host contract (`window.CASE_MANAGEMENT_HOST`) plus standalone |
 
 So the honest answer to "did we implement a declarative case model?" is: **the engine half, yes;
-the experience half, no.** The good news is that the two hardest prerequisites for a model-driven
-UI — server-computed available actions and server-side field-level authorization — already exist.
-Most vendors had to retrofit those.
+the experience half, no.** Server-computed available actions are a strong foundation. The worker-
+permission evaluator is also a useful foundation, but its field semantics and endpoint coverage
+must be completed before the platform can claim that restricted fields never reach a client. That
+completion is a prerequisite for the server-composed architecture below, not an existing guarantee.
 
 ## How the market solved it
 
@@ -55,11 +57,16 @@ are three defensible positions on that axis.
 - **Pro-code where it matters:** a team can replace any rendered region with its own component
   without forking the shell.
 - **One authorization story:** what a worker may see and do is decided server-side, once — never
-  re-derived in a client.
+  re-derived in a client. Field projection is centralized, defaults to deny, and is applied after
+  every platform or extension composer has contributed data.
 - **Versioned with the case:** UI definitions deploy, version, and roll back exactly like the
   behavioral model (`{tenant}:{key}:{version}`).
 - **Portal-embeddable, vendor-neutral:** everything renders through the existing Lit shell and
   `PortalAdapter` contract — any enterprise host via `window.CASE_MANAGEMENT_HOST`, or standalone.
+- **Semantic and channel-neutral:** descriptors carry canonical values, bindings, localization
+  keys, and semantic formatting hints rather than preformatted web strings.
+- **Governed extension model:** custom components and composers are trusted, registered deployment
+  units with bounded capabilities, versioned contracts, and observable failure behavior.
 
 The three proposals differ in exactly one thing: *where* the case model, live instance state, and
 worker permissions are composed into a renderable UI — in the client (A), in the server per request
@@ -93,33 +100,45 @@ renderer that walks the manifest, calls the existing REST API for state, and hon
 `AvailableAction` for every button it draws.
 
 ```json
-"ui": {
-  "dataSchema": { "amount": {"type":"number","format":"currency"},
-                  "customerId": {"type":"string","label":"Customer"} },
-  "summary":   { "fields": ["businessKey","state","amount","slaStatus"] },
-  "sections": [
-    { "id":"work",  "title":"Work",     "component":"plan-tree" },
-    { "id":"docs",  "title":"Documents","component":"document-list" },
-    { "id":"risk",  "title":"Risk",     "component":"acme-risk-panel" }
-  ],
-  "worklist":  { "columns": ["businessKey","title","assignee","slaStatus"] },
-  "forms":     { "reviewForm": { "uiSchema": { "note": {"widget":"textarea"} } } }
+{
+  "ui": {
+    "dataSchema": { "amount": {"type":"number","format":"currency"},
+                    "customerId": {"type":"string","label":"Customer"} },
+    "summary":   { "fields": ["businessKey","state","amount","slaStatus"] },
+    "sections": [
+      { "id":"work",  "title":"Work",     "component":"plan-tree" },
+      { "id":"docs",  "title":"Documents","component":"document-list" },
+      { "id":"risk",  "title":"Risk",     "component":"risk-panel" }
+    ],
+    "worklist":  { "columns": ["businessKey","title","assignee","slaStatus"] },
+    "forms":     { "reviewForm": { "uiSchema": { "note": {"widget":"textarea"} } } }
+  }
 }
 ```
 
-**Pro-code escape hatch:** a component registry. Any `component:` value the shell doesn't recognize
-resolves through `customElements` — the host registers a web component implementing a small slot
-contract (`case`, `planItem`, api client, `PortalAdapter`). Unknown or failed components fall back
-to the built-in renderer, so a manifest never hard-breaks a screen. This is ServiceNow's UI Builder
-pattern and OmniStudio's LWC-in-FlexCard pattern, done with the web-components standard we already
-ship.
+**Pro-code escape hatch:** a governed component registry. A manifest may reference only a logical
+component id that is allowlisted for that platform deployment and case type. The registry maps that
+id and an explicit contract version to a reviewed custom element. It validates component properties
+against a schema and supplies only masked input data plus a case-scoped capability facade. It does
+not pass an access token, unrestricted API client, or raw `PortalAdapter` contract to a component.
+Unknown, incompatible, or failed components fall back to a built-in error or generic renderer so a
+manifest does not hard-break the whole screen.
 
-**Strengths**
+Custom components execute as trusted application code and follow the normal source review, signing,
+release, CSP, Trusted Types, audit, and vulnerability-management controls. A component contributed
+by an untrusted party requires a separate sandbox boundary, such as a restricted cross-origin iframe;
+`customElements` alone is not a security boundary. This preserves the useful ServiceNow and
+OmniStudio component-registry pattern without allowing a manifest author to select arbitrary
+privileged code.
+
+### Strengths
+
 - No new runtime — one deployable artifact, versioned and rolled back with the behavioral model
 - Authorable offline; a future studio/designer edits a document, not a system
 - Smallest server change of the three (validation of the `ui` section on deploy)
 
-**Costs**
+### Costs
+
 - The client composes model + state + permissions itself — field masking must be re-honored in
   every renderer
 - Manifest vocabulary tends to grow into a bad programming language; needs a hard scope line
@@ -133,41 +152,137 @@ Closest analogues: ServiceNow UI Builder, Salesforce OmniStudio, Flowable case p
 render-ready view tree; the client is a thin interpreter of ~15 primitives.
 
 A new endpoint — `GET /case-api/v2/cases/{id}/view` (plus `/worklist/view`, `/tasks/{id}/form`) —
-returns a fully composed descriptor: components, props, data *inline*, and actions attached where
-they render. It is the natural completion of two contracts we already keep: `AvailableAction`
-("everything a renderer needs on first read") and the worker-permission evaluator's field masking,
-which today protects search results but not case pages. The composer is the one place both are
-enforced.
+returns a composed representation with canonical data and actions separated from the presentation
+tree. View nodes bind to authorized data by RFC 6901 JSON Pointer. The server may attach action
+references where they render, but the canonical action definition remains in one top-level list.
+This avoids duplicating data, preserves numeric and temporal types, and lets each channel apply its
+own locale, accessibility, and design-system behavior.
+
+It is the natural completion of two contracts we already keep: `AvailableAction` ("everything a
+renderer needs on first read") and the worker-permission evaluator. The latter currently protects
+selected search and collaboration responses but not ordinary case variables. The composed endpoint
+may be introduced only after the centralized authorization prerequisite below is complete.
 
 ```json
-{ "type": "casePage", "title": "Widget Review · WR-0042",
-  "children": [
-    { "type": "summary", "fields": [
-        { "id":"amount", "label":"Amount", "value":"€ 12,400", "format":"currency" },
-        { "id":"slaStatus", "value":"WARNING", "semantic":"warning" } ] },
-    { "type": "planTree", "items": [ "..." ],
-      "actions": [ { "action":"start", "href":"...", "method":"POST" } ] },
-    { "type": "acme-risk-panel", "props": { "caseId":"..." } }
-  ] }
+{
+  "descriptorVersion": "1.0",
+  "definitionRef": "default:widget-review:7",
+  "locale": "en-GB",
+  "data": {
+    "case": {
+      "id": "case-42",
+      "businessKey": "WR-0042",
+      "variables": { "amount": 12400 },
+      "slaStatus": "WARNING"
+    },
+    "planItems": ["..."],
+    "actions": [
+      { "id": "start-review", "action": "start", "href": "...", "method": "POST" }
+    ]
+  },
+  "view": {
+    "type": "casePage",
+    "title": { "key": "case.widgetReview.title", "args": { "businessKey": "WR-0042" } },
+    "children": [
+      { "type": "summary", "fields": [
+          { "id": "amount", "labelKey": "case.amount",
+            "bind": "/data/case/variables/amount",
+            "format": { "type": "currency", "currency": "EUR" } },
+          { "id": "slaStatus", "bind": "/data/case/slaStatus",
+            "semantic": "warning" }
+      ] },
+      { "type": "planTree", "itemsBind": "/data/planItems",
+        "actionRefs": ["start-review"] },
+      { "type": "extension", "componentId": "risk-panel",
+        "contractVersion": "1", "props": { "caseId": "case-42" } }
+    ]
+  }
+}
 ```
 
 **Pro-code escape hatches, two layers:** server-side *view composers* — a Java SPI mirroring
-`SearchProvider` (`ViewComposer.compose(caseSnapshot, caller)`) so a team contributes computed
+`SearchProvider` (`ViewComposer.compose(scopedSnapshot, context)`) so a team contributes computed
 sections (a risk score, an external-system panel) in code the platform orchestrates; and the same
-client component registry as Proposal A for custom rendering of any descriptor type. A team that
-wants full control ignores the shell entirely and consumes the view API from its own front-end —
-the payload is the product, exactly Pega's DX API posture.
+governed client component registry as Proposal A. A team that wants full control can ignore the shell
+and consume the view API from its own front-end. The API representation, rather than a particular
+renderer, is the product boundary.
 
-**Strengths**
-- Permissions and masking enforced once, server-side — a field a worker may not see never leaves
-  the building
+### Authorization composition prerequisite
+
+Proposal B's security claim depends on one field-authorization contract used by every API response,
+not a collection of provider-specific helper methods:
+
+- Every field has a canonical resource-relative identifier expressed as an RFC 6901 JSON Pointer;
+  nested objects and array elements have defined matching semantics.
+- Read and write decisions are separate. A field visible in a descriptor is not automatically
+  writable through a form or command.
+- A missing or empty `allowedFields` decision means no fields. Unrestricted access requires an
+  explicit `*` decision. Resource denial always overrides field decisions.
+- A central projection service removes unauthorized data from case, task, document, collaboration,
+  search, and view DTOs. It runs after all platform and extension composers have contributed data.
+- Labels, formatting hints, validation messages, matched-field metadata, and action inputs must not
+  disclose the existence or value of a restricted field.
+- Conformance tests enumerate every response family and extension path and assert that restricted
+  fields are absent, including nested values and error responses.
+
+`AvailableAction` is a rendering hint, not delegated authority. Every command is authorized again at
+execution time and retains the platform's optimistic-concurrency and idempotency requirements.
+
+### Caching and concurrency
+
+The existing resource ETag represents a mutable row version and must not be reused as a view ETag.
+A view varies by case version, behavioral and UI definition versions, field-authorization decision,
+locale, channel capabilities, component/composer contract versions, and external data revisions.
+
+The initial implementation therefore returns `Cache-Control: private, no-store`. A later optimization
+may introduce a view-specific validator derived from all representation inputs, including an
+authorization-policy or decision revision supplied by Worker Permissions. A permission change must
+invalidate a previously authorized representation even when the case itself did not change. Shared
+caches must never reuse composed views across callers or tenants.
+
+Mutating actions referenced by a view continue to require `If-Match` against the affected resource
+and `Idempotency-Key` where the underlying command contract requires it. A stale view receives the
+same conflict or precondition response as any other stale API client and refreshes the descriptor.
+
+### Extension orchestration and failure behavior
+
+`ViewComposer` implementations are trusted, registered deployment units. The orchestrator provides a
+masked, case-scoped snapshot; validates every returned contribution; reapplies field projection to
+the combined representation; and rejects undeclared descriptor types or properties. Composers cannot
+mark their own fields as authorized.
+
+Execution has bounded parallelism, per-composer timeouts, circuit breaking, deterministic ordering,
+stable component ids, duplicate-id rejection, and distributed tracing. A non-essential composer
+failure produces a typed warning and an unavailable section without failing the case page. Failure of
+an essential security or core-data composer fails closed. Logs, metrics, and traces must not contain
+unmasked case data.
+
+### Descriptor governance
+
+The authoring manifest and runtime descriptor each have a published JSON Schema and independent
+semantic version. Additive changes remain compatible within a major version; removed or redefined
+primitives require a new major version and a documented migration path. Published model versions are
+immutable, and a case continues to resolve the UI definition version to which it is bound until an
+explicit case migration occurs.
+
+Primitive contracts include localization keys, raw values, semantic formatting, focus order,
+validation linkage, accessible names, responsive behavior, and design-token hooks. Renderers must
+reject unsupported major versions predictably and show an auditable compatibility error rather than
+silently dropping required content.
+
+### Strengths
+
+- Once the authorization prerequisite is complete, permissions and masking are enforced once,
+  server-side — a field a worker may not see never leaves the server
 - Logic changes land without redeploying any front-end; portal, mobile, and future channels
   consume one payload
 - Thinnest possible client — best fit for embedding in portals we don't own
 
-**Costs**
+### Costs
+
 - The descriptor vocabulary is a public contract; versioning it is real work
-- Chattier: a view round-trip per screen; needs caching + ETag discipline (we have ETags)
+- A view round-trip is required per screen; safe caching needs a representation-specific validator,
+  not the existing resource ETag
 - Presentation logic migrates into the server — a cultural shift, and harder to preview in a
   designer without a running instance
 
@@ -186,7 +301,7 @@ the REST API, `AvailableAction`, and the event feed, with zero rendering opinion
 app is a starting point the team edits; regeneration flows through git as an ordinary diff
 (protected regions, or a base-branch merge like OpenAPI generators).
 
-```
+```text
 $ casemgmt generate --definition widget-review@7 --out apps/widget-review
   ✓ types/WidgetReviewVars.ts        # from ui.dataSchema
   ✓ forms/ReviewForm.ts              # from forms.reviewForm JSON Schema
@@ -200,12 +315,14 @@ changes?" The answer is the SDK boundary: generated code may only touch the API 
 `@casemgmt/sdk`, so platform upgrades ship as an npm bump, and regeneration only touches the
 declaratively-owned files.
 
-**Strengths**
+### Strengths
+
 - Maximal flexibility and native performance; type-safe against the case's actual data model
 - No runtime interpreter to build, version, or debug — the simplest platform surface
 - Fits teams that already build pro-code portal front-ends (the Backbase-journey model)
 
-**Costs**
+### Costs
+
 - Model changes require a front-end build + deploy — business users never self-serve
 - Drift: N generated apps age at N different rates against the platform
 - "Render most of the case logic from the model" is only true on day one; it decays with every
@@ -220,7 +337,7 @@ UI, OutSystems-style scaffolding.
 |---|---|---|---|
 | New case type → working UI, no FE code | Yes | Yes | Day one only |
 | Change logic without FE deploy | Yes | Yes | No |
-| Field-level authz enforced once | Client must re-honor | Server, by construction | Client must re-honor |
+| Field-level authz enforced once | Client must re-honor | Server, after the authorization prerequisite | Client must re-honor |
 | Pro-code ceiling | Component slots | Slots + composers + own FE | Unlimited |
 | Server investment | Small | Large (composer + contract) | Small |
 | Front-end investment | Large (interpreter) | Small (thin renderer) | Medium (SDK + codegen) |
@@ -232,22 +349,44 @@ UI, OutSystems-style scaffolding.
 **Take B as the destination, A as the authoring format, and the component registry as the shared
 escape hatch.** The manifest of Proposal A becomes the *input* the Proposal B composer consumes —
 authored at design time, versioned with the definition, but merged with state and permissions on
-the server, where our field masking and `AvailableAction` discipline already live. Proposal C's
-headless SDK is worth building regardless (the thin renderer needs it anyway), but as an
-integration option for teams that opt out — not the platform's main path.
+the server. `AvailableAction` already provides a strong runtime contract. Worker Permissions provides
+the authorization foundation, but field projection must first become centralized, fail closed, and
+complete across all response types. Proposal C's headless SDK is worth building regardless (the thin
+renderer needs it anyway), but as an integration option for teams that opt out — not the platform's
+main path.
 
-This is deliberately the Pega-shaped answer with a ServiceNow-shaped authoring story: in a bank,
-the argument that wins is that *a field a worker may not see never reaches the browser* — and only
-B gives that by construction.
+This is deliberately the Pega-shaped answer with a ServiceNow-shaped authoring story. For a regulated
+platform, the decisive property is that *a field a worker may not see never reaches the browser*.
+Proposal B can provide that property once Phase 0 is complete and every subsequent extension remains
+inside the same projection boundary.
 
 | Phase | Scope |
 |---|---|
-| 1 | Define the `ui` manifest section + deploy-time validation; typed `dataSchema` for `vars` (also fixes silent-typo criteria against undeclared vars, issue #28). |
-| 2 | View composer service + `/view` endpoints behind the descriptor vocabulary (~15 primitives, versioned like the OpenAPI contract); thin renderer replaces the hand-coded panels in the Lit shell. |
-| 3 | Component registry contract for custom elements (client) and `ViewComposer` SPI (server); conformance tests that assert masked fields never appear in any view payload. Give the embedded-host global the same treatment: export and document the `CASE_MANAGEMENT_HOST` contract type, since custom components will receive it. |
-| 4 | Headless `@casemgmt/sdk` extracted from the renderer for opt-out teams; optional codegen on top if demand appears. |
+| 0 | Define canonical field paths and read/write semantics; make missing or empty field decisions deny by default; implement one central projection service across case, task, document, collaboration, search, and error DTOs; add negative authorization conformance tests before exposing a composed view. |
+| 1 | Define and publish JSON Schemas for the versioned `ui` authoring manifest and runtime descriptor; add typed `dataSchema` for `vars`; separately validate criterion expressions against declared variable and plan-item symbols at deploy time. |
+| 2 | Implement the orchestrated composer service and `/view` endpoints with canonical data separated from presentation bindings; reauthorize every action at execution; publish OpenAPI and start with `Cache-Control: private, no-store`. |
+| 3 | Replace the hand-coded Lit panels with a thin renderer for the bounded primitive vocabulary; implement localization, accessibility, responsive behavior, design-token mapping, unsupported-version handling, and embedded/standalone conformance tests. |
+| 4 | Add the allowlisted, versioned component registry and bounded `ViewComposer` SPI; implement schema validation, timeout and failure isolation, tracing, post-composition projection, and security tests for extension output. Export and document the normalized host contract for platform integration, while custom components receive only a scoped capability facade. |
+| 5 | Extract the headless `@casemgmt/sdk` from the renderer for opt-out teams; add optional code generation only if adoption evidence justifies its lifecycle and migration cost. |
 
-## Revision 2 — reassessed against vendor-neutral portal integration
+## Decision gates
+
+The following decisions must be recorded before implementation starts:
+
+- **Worker Permissions contract:** confirm canonical field identifiers, separate read/write actions,
+  explicit wildcard semantics, and a policy or decision revision suitable for cache invalidation. If
+  the upstream API cannot supply them, define a fail-closed platform adapter and its limitations.
+- **Extension trust level:** confirm that custom components and composers are platform-reviewed
+  deployment units. Tenant-uploaded or third-party executable extensions are out of scope unless a
+  separate sandbox architecture and operating model are approved.
+- **Channel scope:** identify the first supported channels and their capability profiles. Web,
+  embedded portal, and standalone Lit can share one primitive renderer; a native-mobile claim needs
+  its own renderer, compatibility matrix, and conformance suite.
+- **Availability behavior:** classify core and optional composers, define page-level latency and
+  availability objectives, and agree which failures produce a partial view versus a fail-closed
+  response.
+
+## Vendor-neutral portal reassessment
 
 Since the first revision, main merged PR #86: the two vendor-specific portal adapters collapsed
 into one generic `EmbeddedPortalAdapter` behind `window.CASE_MANAGEMENT_HOST`, and
@@ -261,23 +400,28 @@ which change the recommendation:
   names, action ids, and theming hooks in the `ui` section follow the same rule the adapters just
   adopted: generic contract, host-specific behavior injected through the adapter — never named in
   the model.
-- **The host contract is now a dependency of the escape hatch.** Custom components registered by a
-  host will need typed access to the same normalized contract; today `CASE_MANAGEMENT_HOST`'s
-  shape is neither exported nor documented (flagged in the PR #86 review). Folded into Phase 3
-  above.
+- **The host contract is now a dependency of the platform renderer.** The platform needs an exported,
+  documented `CASE_MANAGEMENT_HOST` type and a normalized internal adapter. Custom components do not
+  receive that raw contract; the registry supplies only the scoped capabilities declared by the
+  component contract. Folded into Phase 4 above.
 
 ## Sources
 
+Vendor and standards links were verified on 2026-08-22. Primary vendor documentation is preferred
+over community or third-party architecture summaries.
+
 - Pega — [Digital Experience (DX) API](https://community.pega.com/digital-experience-api) ·
-  [Constellation DX API](https://academy.pega.com/topic/constellation-dx-api/v2) ·
-  [Constellation architecture explained](https://medium.com/@harshsonionline/pega-constellation-architecture-explained-c1bbccba53e2)
-- ServiceNow — [UI Builder](https://www.servicenow.com/products/ui-builder.html) ·
-  [Declarative Actions guide](https://www.servicenow.com/community/developer-blog/declarative-actions-in-servicenow-the-complete-guide/ba-p/2781607)
+  [Constellation DX API](https://academy.pega.com/topic/constellation-dx-api/v2)
+- ServiceNow — [UI Builder](https://www.servicenow.com/docs/r/application-development/ui-builder/ui-builder-overview.html) ·
+  [Custom components](https://www.servicenow.com/docs/r/application-development/ui-builder/component-builder.html)
 - Appian — [Case Management Studio overview](https://docs.appian.com/suite/help/25.4/case-management-studio-overview.html) ·
   [Low-code configurations](https://docs.appian.com/suite/help/24.3/cms-low-code-configurations.html)
 - Salesforce — [OmniStudio FlexCards](https://trailhead.salesforce.com/content/learn/modules/omnistudio-flexcard-fundamentals/get-to-know-omnistudio-flexcards) ·
-  [Building Forms decision guide](https://architect.salesforce.com/docs/architect/decision-guides/guide/build-forms)
+  [FlexCard component reference](https://developer.salesforce.com/docs/platform/lightning-component-reference/guide/lightning-omnistudio-flexcard.html)
 - Flowable — [Case Views](https://documentation.flowable.com/latest/reactmodel/cmmn/concept/case-view) ·
   [CMMN solution](https://www.flowable.com/solutions/cmmn)
-- Backbase — [Journey architecture](https://manishpathak99.medium.com/backbase-journey-architecture-ac24672c5fa7) ·
-  [Micro-frontends at Backbase](https://engineering.backbase.com/2024/05/15/maintaining-legacy-code-with-micro-frontends/)
+- Backbase — [Micro-frontends at Backbase](https://engineering.backbase.com/2024/05/15/maintaining-legacy-code-with-micro-frontends/)
+- Standards — [RFC 6901: JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901) ·
+  [RFC 9111: HTTP Caching](https://www.rfc-editor.org/rfc/rfc9111) ·
+  [JSON Schema 2020-12](https://json-schema.org/draft/2020-12) ·
+  [WCAG 2.2](https://www.w3.org/TR/WCAG22/)

--- a/docs/declarative-case-ui-proposal.md
+++ b/docs/declarative-case-ui-proposal.md
@@ -1,0 +1,283 @@
+# Declarative Case UI — Proposal
+
+We already have a declarative *behavioral* case model. This document maps the gap to a declarative
+*presentation* model — where the front-end renders most case logic from the model, with pro-code
+escape hatches — surveys how five competitors solved it, and puts forward three architectures.
+
+Status: for discussion. Revision 2 (reassessed against the vendor-neutral portal integration in
+PR #86 / commit `1a51cea`).
+
+## What we have today — and what "declarative" currently stops at
+
+The platform's case definition is already a declarative document: one JSON artifact per case type,
+versioned on deploy, interpreted at runtime by `PlanModelEvaluator`. It answers **what work exists
+and when it becomes available**. It does not answer **what the screen looks like** — the Lit
+web-components shell hand-codes two generic panels and knows nothing about any particular case type.
+
+| Layer | Declarative today? | Where it lives |
+|---|---|---|
+| Work model | Yes | Plan items: stages, human tasks, milestones, process tasks; entry/exit criteria (sandboxed JUEL); required / manual-activation / repetition semantics |
+| Form validation | Yes | JSON Schema per `formKey`, enforced server-side on task completion (422 with RFC 6901 pointers) |
+| Actions | Yes (runtime) | `AvailableAction`: server computes `action / name / href / method / formKey` per resource — a renderer never guesses what a caller may do |
+| Authorization | Yes (runtime) | Worker-permission evaluator with per-field masking, already applied inside search providers |
+| Form rendering | No | Schema validates payloads; nothing renders it. No uiSchema, no widget hints, no layout |
+| Case data model | No | `vars` is an untyped bag; criteria reference it blind, the UI can't render what it can't name |
+| Views & layout | No | No summary panel model, no tabs/sections, no worklist column config, no per-type theming or labels |
+| Front-end | No | Hand-coded Lit shell (generic case list + task list) behind `PortalAdapter` — one vendor-neutral embedded host contract (`window.CASE_MANAGEMENT_HOST`) plus standalone |
+
+So the honest answer to "did we implement a declarative case model?" is: **the engine half, yes;
+the experience half, no.** The good news is that the two hardest prerequisites for a model-driven
+UI — server-computed available actions and server-side field-level authorization — already exist.
+Most vendors had to retrofit those.
+
+## How the market solved it
+
+Five relevant systems, read for one question: *where does the UI model live, and what happens when
+the model isn't enough?*
+
+| Platform | UI model lives | Composed | Pro-code escape hatch | Takeaway for us |
+|---|---|---|---|---|
+| Pega Constellation | View rules (metadata) on the server | Runtime, server-side — DX API v2 returns data + UI metadata per case/assignment | Custom DX components registered in the client engine; own front-end against the same API | The purest server-driven-UI play; one API serves web, mobile, and embedded renderers |
+| ServiceNow (UI Builder) | Declarative pages + components, design time | Design time; client interprets page config | Custom Next Experience (web) components dropped into declarative pages; declarative actions | Design-time page model + component registry is enough for most workspace UIs |
+| Appian Case Mgmt Studio | Out-of-box record types + SAIL interfaces, configured no-code | Design time (Studio) over a fixed app skeleton | Drop to low-code SAIL / process models beneath the studio layer | "Configurable product, escape to the platform beneath" — fast start, bounded ceiling |
+| Salesforce OmniStudio | FlexCards / OmniScripts as JSON metadata | Design time; embeddable anywhere a Lightning page renders | Custom LWCs inside cards/scripts; Apex behind integration procedures | Small composable UI units embed well in someone else's portal — our exact situation |
+| Flowable Work | Case model carries "case pages" + form model | Design time; generic Work UI interprets | Custom form components; build your own UI on the REST API | Closest to our stack: CMMN-lite model extended with view artifacts, one generic renderer |
+
+Backbase — the nearest banking-portal analogue — is the counter-example: journeys are **pro-code
+Angular micro-frontends that are configurable**, not model-rendered. That is the trade every vendor
+makes somewhere on one axis: **where model-driven ends and code begins.** The three proposals below
+are three defensible positions on that axis.
+
+## Design goals
+
+- **Model-first rendering:** a new case type ships a working UI with zero front-end code —
+  worklist, case page, task forms, actions.
+- **Pro-code where it matters:** a team can replace any rendered region with its own component
+  without forking the shell.
+- **One authorization story:** what a worker may see and do is decided server-side, once — never
+  re-derived in a client.
+- **Versioned with the case:** UI definitions deploy, version, and roll back exactly like the
+  behavioral model (`{tenant}:{key}:{version}`).
+- **Portal-embeddable, vendor-neutral:** everything renders through the existing Lit shell and
+  `PortalAdapter` contract — any enterprise host via `window.CASE_MANAGEMENT_HOST`, or standalone.
+
+The three proposals differ in exactly one thing: *where* the case model, live instance state, and
+worker permissions are composed into a renderable UI — in the client (A), in the server per request
+(B), or once at build time (C). Everything downstream of that choice follows.
+
+```mermaid
+flowchart LR
+  subgraph A["A · Manifest (design-time model)"]
+    a1["definition + ui manifest"] --> a2["server: state · actions · permissions (REST)"]
+    a2 --> a3["client composes + renders"]
+  end
+  subgraph B["B · View API (runtime model)"]
+    b1["definition + ui manifest"] --> b2["server composes view\n(state ∘ permissions)"]
+    b2 -- "view tree" --> b3["thin client renderer"]
+  end
+  subgraph C["C · Generated app (build-time model)"]
+    c1["definition + hints"] -- codegen --> c2["generated app + SDK"]
+    c2 --> c3["server: state · actions · permissions (REST)"]
+  end
+```
+
+## Proposal A — Case App Manifest (design-time model, client-interpreted)
+
+**Thesis:** extend the case definition with a presentation section; the Lit shell becomes a generic
+interpreter of it.
+
+The definition JSON (or a versioned sibling artifact deployed with it) gains a `ui` section: a
+typed data schema for `vars`, a summary layout, detail sections, worklist columns, per-form
+uiSchema, and action placement. The shell stops being two hand-coded panels and becomes one
+renderer that walks the manifest, calls the existing REST API for state, and honors
+`AvailableAction` for every button it draws.
+
+```json
+"ui": {
+  "dataSchema": { "amount": {"type":"number","format":"currency"},
+                  "customerId": {"type":"string","label":"Customer"} },
+  "summary":   { "fields": ["businessKey","state","amount","slaStatus"] },
+  "sections": [
+    { "id":"work",  "title":"Work",     "component":"plan-tree" },
+    { "id":"docs",  "title":"Documents","component":"document-list" },
+    { "id":"risk",  "title":"Risk",     "component":"acme-risk-panel" }
+  ],
+  "worklist":  { "columns": ["businessKey","title","assignee","slaStatus"] },
+  "forms":     { "reviewForm": { "uiSchema": { "note": {"widget":"textarea"} } } }
+}
+```
+
+**Pro-code escape hatch:** a component registry. Any `component:` value the shell doesn't recognize
+resolves through `customElements` — the host registers a web component implementing a small slot
+contract (`case`, `planItem`, api client, `PortalAdapter`). Unknown or failed components fall back
+to the built-in renderer, so a manifest never hard-breaks a screen. This is ServiceNow's UI Builder
+pattern and OmniStudio's LWC-in-FlexCard pattern, done with the web-components standard we already
+ship.
+
+**Strengths**
+- No new runtime — one deployable artifact, versioned and rolled back with the behavioral model
+- Authorable offline; a future studio/designer edits a document, not a system
+- Smallest server change of the three (validation of the `ui` section on deploy)
+
+**Costs**
+- The client composes model + state + permissions itself — field masking must be re-honored in
+  every renderer
+- Manifest vocabulary tends to grow into a bad programming language; needs a hard scope line
+- Every deployed manifest couples to the shell's interpreter version — upgrades ripple
+
+Closest analogues: ServiceNow UI Builder, Salesforce OmniStudio, Flowable case pages.
+
+## Proposal B — Composed View API (runtime model, server-driven UI)
+
+**Thesis:** the server merges definition, instance state, and worker permissions into a
+render-ready view tree; the client is a thin interpreter of ~15 primitives.
+
+A new endpoint — `GET /case-api/v2/cases/{id}/view` (plus `/worklist/view`, `/tasks/{id}/form`) —
+returns a fully composed descriptor: components, props, data *inline*, and actions attached where
+they render. It is the natural completion of two contracts we already keep: `AvailableAction`
+("everything a renderer needs on first read") and the worker-permission evaluator's field masking,
+which today protects search results but not case pages. The composer is the one place both are
+enforced.
+
+```json
+{ "type": "casePage", "title": "Widget Review · WR-0042",
+  "children": [
+    { "type": "summary", "fields": [
+        { "id":"amount", "label":"Amount", "value":"€ 12,400", "format":"currency" },
+        { "id":"slaStatus", "value":"WARNING", "semantic":"warning" } ] },
+    { "type": "planTree", "items": [ "..." ],
+      "actions": [ { "action":"start", "href":"...", "method":"POST" } ] },
+    { "type": "acme-risk-panel", "props": { "caseId":"..." } }
+  ] }
+```
+
+**Pro-code escape hatches, two layers:** server-side *view composers* — a Java SPI mirroring
+`SearchProvider` (`ViewComposer.compose(caseSnapshot, caller)`) so a team contributes computed
+sections (a risk score, an external-system panel) in code the platform orchestrates; and the same
+client component registry as Proposal A for custom rendering of any descriptor type. A team that
+wants full control ignores the shell entirely and consumes the view API from its own front-end —
+the payload is the product, exactly Pega's DX API posture.
+
+**Strengths**
+- Permissions and masking enforced once, server-side — a field a worker may not see never leaves
+  the building
+- Logic changes land without redeploying any front-end; portal, mobile, and future channels
+  consume one payload
+- Thinnest possible client — best fit for embedding in portals we don't own
+
+**Costs**
+- The descriptor vocabulary is a public contract; versioning it is real work
+- Chattier: a view round-trip per screen; needs caching + ETag discipline (we have ETags)
+- Presentation logic migrates into the server — a cultural shift, and harder to preview in a
+  designer without a running instance
+
+Closest analogue: Pega Constellation / DX API v2 — the strongest reference implementation of this
+pattern in case management.
+
+## Proposal C — Generated App + Headless SDK (build-time model, pro-code-first)
+
+**Thesis:** the model compiles to typed front-end code a team then owns; declarative at authoring
+time, plain code at runtime.
+
+Keep the behavioral model lean and add only minimal UI hints. A CLI (`casemgmt generate`) compiles
+a definition into typed TypeScript: interfaces for `vars`, a form component per JSON Schema, a
+routed case page and worklist assembled from a **headless SDK** — stores and controllers wrapping
+the REST API, `AvailableAction`, and the event feed, with zero rendering opinions. The generated
+app is a starting point the team edits; regeneration flows through git as an ordinary diff
+(protected regions, or a base-branch merge like OpenAPI generators).
+
+```
+$ casemgmt generate --definition widget-review@7 --out apps/widget-review
+  ✓ types/WidgetReviewVars.ts        # from ui.dataSchema
+  ✓ forms/ReviewForm.ts              # from forms.reviewForm JSON Schema
+  ✓ pages/case-page.ts, worklist.ts  # composed from @casemgmt/sdk primitives
+  → edit anything; `generate --update` merges model changes as a git diff
+```
+
+**Pro-code escape hatch: everything, trivially** — it is code. The discipline problem inverts:
+instead of asking "can we customize?", we must ask "how do N customized apps absorb model
+changes?" The answer is the SDK boundary: generated code may only touch the API through
+`@casemgmt/sdk`, so platform upgrades ship as an npm bump, and regeneration only touches the
+declaratively-owned files.
+
+**Strengths**
+- Maximal flexibility and native performance; type-safe against the case's actual data model
+- No runtime interpreter to build, version, or debug — the simplest platform surface
+- Fits teams that already build pro-code portal front-ends (the Backbase-journey model)
+
+**Costs**
+- Model changes require a front-end build + deploy — business users never self-serve
+- Drift: N generated apps age at N different rates against the platform
+- "Render most of the case logic from the model" is only true on day one; it decays with every
+  manual edit
+
+Closest analogues: Backbase journeys (pro-code configurable), OpenAPI client generation applied to
+UI, OutSystems-style scaffolding.
+
+## Comparison
+
+| Criterion | A · Manifest | B · View API | C · Generated |
+|---|---|---|---|
+| New case type → working UI, no FE code | Yes | Yes | Day one only |
+| Change logic without FE deploy | Yes | Yes | No |
+| Field-level authz enforced once | Client must re-honor | Server, by construction | Client must re-honor |
+| Pro-code ceiling | Component slots | Slots + composers + own FE | Unlimited |
+| Server investment | Small | Large (composer + contract) | Small |
+| Front-end investment | Large (interpreter) | Small (thin renderer) | Medium (SDK + codegen) |
+| Future no-code studio fits on top | Naturally (edits the manifest) | Yes (authors composer input) | Poorly |
+| Multi-channel (portal/mobile) reuse | Per-client interpreter | One payload | Per-app |
+
+## Recommendation
+
+**Take B as the destination, A as the authoring format, and the component registry as the shared
+escape hatch.** The manifest of Proposal A becomes the *input* the Proposal B composer consumes —
+authored at design time, versioned with the definition, but merged with state and permissions on
+the server, where our field masking and `AvailableAction` discipline already live. Proposal C's
+headless SDK is worth building regardless (the thin renderer needs it anyway), but as an
+integration option for teams that opt out — not the platform's main path.
+
+This is deliberately the Pega-shaped answer with a ServiceNow-shaped authoring story: in a bank,
+the argument that wins is that *a field a worker may not see never reaches the browser* — and only
+B gives that by construction.
+
+| Phase | Scope |
+|---|---|
+| 1 | Define the `ui` manifest section + deploy-time validation; typed `dataSchema` for `vars` (also fixes silent-typo criteria against undeclared vars, issue #28). |
+| 2 | View composer service + `/view` endpoints behind the descriptor vocabulary (~15 primitives, versioned like the OpenAPI contract); thin renderer replaces the hand-coded panels in the Lit shell. |
+| 3 | Component registry contract for custom elements (client) and `ViewComposer` SPI (server); conformance tests that assert masked fields never appear in any view payload. Give the embedded-host global the same treatment: export and document the `CASE_MANAGEMENT_HOST` contract type, since custom components will receive it. |
+| 4 | Headless `@casemgmt/sdk` extracted from the renderer for opt-out teams; optional codegen on top if demand appears. |
+
+## Revision 2 — reassessed against vendor-neutral portal integration
+
+Since the first revision, main merged PR #86: the two vendor-specific portal adapters collapsed
+into one generic `EmbeddedPortalAdapter` behind `window.CASE_MANAGEMENT_HOST`, and
+organization-specific terminology left the docs. Three consequences for this proposal, none of
+which change the recommendation:
+
+- **It strengthens Proposal B.** The platform is now positioned as a product for *any* enterprise
+  host, not one bank's two portals. One server-composed view payload consumed by N vendor-neutral
+  hosts is exactly the multi-host story; per-host generated apps (Proposal C) multiply instead.
+- **The manifest and descriptor vocabularies must be vendor-neutral from day one.** Component
+  names, action ids, and theming hooks in the `ui` section follow the same rule the adapters just
+  adopted: generic contract, host-specific behavior injected through the adapter — never named in
+  the model.
+- **The host contract is now a dependency of the escape hatch.** Custom components registered by a
+  host will need typed access to the same normalized contract; today `CASE_MANAGEMENT_HOST`'s
+  shape is neither exported nor documented (flagged in the PR #86 review). Folded into Phase 3
+  above.
+
+## Sources
+
+- Pega — [Digital Experience (DX) API](https://community.pega.com/digital-experience-api) ·
+  [Constellation DX API](https://academy.pega.com/topic/constellation-dx-api/v2) ·
+  [Constellation architecture explained](https://medium.com/@harshsonionline/pega-constellation-architecture-explained-c1bbccba53e2)
+- ServiceNow — [UI Builder](https://www.servicenow.com/products/ui-builder.html) ·
+  [Declarative Actions guide](https://www.servicenow.com/community/developer-blog/declarative-actions-in-servicenow-the-complete-guide/ba-p/2781607)
+- Appian — [Case Management Studio overview](https://docs.appian.com/suite/help/25.4/case-management-studio-overview.html) ·
+  [Low-code configurations](https://docs.appian.com/suite/help/24.3/cms-low-code-configurations.html)
+- Salesforce — [OmniStudio FlexCards](https://trailhead.salesforce.com/content/learn/modules/omnistudio-flexcard-fundamentals/get-to-know-omnistudio-flexcards) ·
+  [Building Forms decision guide](https://architect.salesforce.com/docs/architect/decision-guides/guide/build-forms)
+- Flowable — [Case Views](https://documentation.flowable.com/latest/reactmodel/cmmn/concept/case-view) ·
+  [CMMN solution](https://www.flowable.com/solutions/cmmn)
+- Backbase — [Journey architecture](https://manishpathak99.medium.com/backbase-journey-architecture-ac24672c5fa7) ·
+  [Micro-frontends at Backbase](https://engineering.backbase.com/2024/05/15/maintaining-legacy-code-with-micro-frontends/)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -2,8 +2,6 @@
 
 Documentation for building on the case management library.
 
-**Searchable version:** https://claude.ai/code/artifact/fc27b66e-85fd-4899-8d06-f7f8e0b47087
-
 | Guide | Read it when |
 |---|---|
 | [Quick start](quickstart.md) | You want a running case in 15 minutes |
@@ -13,6 +11,8 @@ Documentation for building on the case management library.
 | [Operations](operations.md) | You're deploying, integrating or debugging |
 | [Search architecture](../search-architecture.md) | You're implementing or integrating search providers |
 | [Document management and search](../document-management-and-search.md) | You're linking documents or adding document search/extraction |
+| [Declarative model architecture](../declarative-case-model-architecture.md) | You're designing the target model bundle, field catalog, search profiles or generated artifacts |
+| [Declarative UI proposal](../declarative-case-ui-proposal.md) | You're evaluating model-driven views and the server-composed View API |
 
 Reference material lives elsewhere: [`openapi-specs.md`](../../openapi-specs.md) is the API
 contract, [`db-design.sql`](../../db-design.sql) is the schema, [`FINDINGS.md`](../../FINDINGS.md)

--- a/docs/guide/case-definitions.md
+++ b/docs/guide/case-definitions.md
@@ -3,6 +3,10 @@
 A definition is one JSON document. Deploying it mints a new version; the id is
 `{tenant}:{key}:{version}`.
 
+This guide documents the format accepted by the current runtime. The proposed composable bundle,
+canonical field catalog, commands, search profiles and view manifests are described separately in
+[`declarative-case-model-architecture.md`](../declarative-case-model-architecture.md).
+
 ## Top level
 
 | Field | Required | Meaning |
@@ -42,9 +46,9 @@ Criteria are JUEL, evaluated in a sandbox with no access to arbitrary Java. Two 
 | `items` | Other plan items by `defKey` | `${items.assess.state == 'COMPLETED'}` |
 | `vars` | Case variables | `${vars.amount > 1000}` |
 
-> **Typos fail silently.** A criterion referencing a `defKey` that doesn't exist evaluates against a
-> null and simply never fires — no error at deploy time, none at runtime. Check your `defKey`s.
-> ([Issue #28](https://github.com/Ronrock/case-management-design/issues/28).)
+> **Reference validation:** deployment rejects criteria that reference an unknown plan-item
+> `defKey`. Case-variable references remain untyped and are not statically validated in the current
+> format; the target canonical data schema closes that remaining gap.
 
 ## Forms
 

--- a/docs/search-architecture.md
+++ b/docs/search-architecture.md
@@ -4,6 +4,12 @@ Search is a reusable platform capability embedded in each domain-owned case appl
 workers one consistent way to find cases, tasks, worklist items, document references, timeline
 entries and related business references without turning search into the system of record.
 
+This document distinguishes the implemented provider foundation from the target declarative search
+contract. The target model is defined in
+[`declarative-case-model-architecture.md`](declarative-case-model-architecture.md). It replaces raw
+field paths and arbitrary filter maps with stable search parameters, profiles, permission-aware
+descriptors, and generated projection plans.
+
 The default implementation is projection-first: local Oracle-backed projections and indexes are
 used before any external search infrastructure is introduced. External search platforms, enterprise
 reference providers and semantic/vector search are extension points, not MVP dependencies.
@@ -20,6 +26,9 @@ reference providers and semantic/vector search are extension points, not MVP dep
 | Host neutral | Embedded enterprise portals and standalone shells consume the same Search API and typed client. |
 | Optional federation | Cross-domain search is an event-fed projection concern, not central ownership of domain case data. |
 | Controlled semantic search | AI/vector search is optional and only over approved indexed content with audit and masking controls. |
+| Stable query contract | Clients use versioned search parameter ids, never storage columns or mutable JSON paths. |
+| Capability-specific policy | Match, disclose, filter, sort, facet, suggest, highlight, export and semantic use are authorized independently. |
+| Model-compiled plans | Domain models describe intent; provider-specific projection and index plans are generated and reviewed. |
 
 ## Component Model
 
@@ -34,11 +43,14 @@ flowchart LR
   component["Search UI / Lit component"]
   client["Generated API client"]
   api["Search API"]
+  descriptor["Permission-aware Search Descriptor"]
   orchestrator["Search Orchestrator"]
   planner["Query planner"]
   auth["Authorization and field policy"]
   wp["Worker Permissions API"]
   merge["Merge, rank, deduplicate"]
+  model["Case model bundle\nsearch parameters + profiles"]
+  compiler["Model validator and compiler"]
 
   subgraph Providers["Search providers"]
     cases["Case projection provider"]
@@ -56,6 +68,11 @@ flowchart LR
   enterpriseServices["Enterprise services"]
   vector["Optional search/vector index"]
 
+  model --> compiler
+  compiler --> planner
+  compiler --> descriptor
+  auth --> descriptor
+  descriptor --> component
   embeddedA --> component
   embeddedB --> component
   shell --> component
@@ -90,7 +107,54 @@ flowchart LR
 
 `SearchOrchestrator` owns provider selection, bounded execution, ranking, deduplication, provider
 status reporting and warnings. Providers own their own query implementation, source freshness and
-result enrichment.
+result enrichment. The model compiler and Search Descriptor are target components; the current
+implementation registers providers and accepts filters directly in code.
+
+## Declarative Search Contract
+
+A field is not simply `searchable`. The canonical field catalog declares the maximum discovery
+capabilities policy permits. Versioned search parameters define stable client-facing names and typed
+operators. Search profiles assemble those parameters into a workbench, document picker, related-case
+view, or other search experience.
+
+| Model element | Responsibility |
+|---|---|
+| Canonical field | Type, stable id, current JSON Pointer, owner, classification, purpose and policy. |
+| Discovery ceiling | Maximum query modes and whether filtering, sorting, facets, suggestions, highlights, result disclosure or semantic use can ever be enabled. |
+| Search parameter | Stable query id, type, operators, source field/expression, aliases and provider. |
+| Search profile | Scopes, selected parameters, ranking, result view, pagination and availability behavior for one experience. |
+| Relationship | Authorized edge definition for related cases, duplicates, references or evidence. |
+| Physical plan | Generated provider mapping, projection schema, index strategy, backfill and activation plan. |
+
+Search profile capabilities can narrow a field's discovery ceiling but cannot expand it. A model with
+an unsupported operator/type combination, a missing source, or a downstream capability exceeding a
+field ceiling is rejected before publication.
+
+Stable parameter ids decouple clients from model evolution. For example, parameter `customer` may
+map to `/customerId` in one case-data version and `/customer/id` in the next without changing saved
+queries or UI bindings. Deprecated aliases are explicit, and retired ids are never reused.
+
+The target query contract is a typed expression tree:
+
+```json
+{
+  "profile": "case-workbench",
+  "text": "late review",
+  "where": {
+    "all": [
+      { "parameter": "state", "operator": "in", "value": ["open", "in-review"] },
+      { "parameter": "customer", "operator": "eq", "value": "customer-42" }
+    ]
+  },
+  "sort": ["updated-at-desc"],
+  "cursor": null,
+  "limit": 25
+}
+```
+
+The query compiler validates parameter existence, type, operator, profile membership, provider
+capability and caller authorization before invoking a provider. Provider-specific SQL, JSON paths,
+search syntax and index names never cross the Search API boundary.
 
 ## Cascading Query Flow
 
@@ -163,6 +227,26 @@ The document provider follows the same contract, but with an additional rule: do
 filtered through the Worker Permissions port before they are returned. Missing or unavailable
 authorization produces an `authorization-unavailable` warning and no document results.
 
+## Generated Projection and Index Plans
+
+Domain authors declare search semantics, not DDL. The model compiler combines parameter operations,
+data shape, cardinality hints, provider capabilities and the deployment profile into a reviewable
+physical plan.
+
+For the Oracle profile, likely strategies are:
+
+| Search need | Candidate implementation |
+|---|---|
+| Exact or range query on selected scalar fields | Relational projection column with B-tree or function-based index. |
+| Repeated scalar values in arrays | Multivalue JSON index or normalized child projection. |
+| Approved ad-hoc structural and full-text JSON queries | JSON search index or Oracle Text projection. |
+| Heavy cross-domain relevance and aggregation | Optional external search projection with separate justification. |
+
+The generated plan includes projection schema, source mappings, index DDL, transformation version,
+tombstone handling, idempotency key, checkpoint strategy, backfill, parity tests, alias activation,
+rollback and provenance. Backend index names, analyzers and JSON paths are not public model or API
+identifiers.
+
 ## Document Search and Extraction
 
 The platform does not store document binaries in the case database. A case stores document
@@ -230,6 +314,17 @@ The Search API lives under `/case-api/v2/search`.
 Responses include items, page metadata, warnings and provider status. Facets are returned when a
 registered provider supports them.
 
+The target contract adds `GET /search/capabilities?profile={id}` (or the equivalent through the
+server-composed View API). It returns a caller-specific Search Descriptor containing only authorized
+parameters, operators, facets, sorts, result fields and relationship expansions. The Lit search
+component renders from this descriptor and never derives field permissions locally.
+
+The current arbitrary `filters` map remains a transitional implementation detail. The target
+`POST /search/query` uses stable parameter ids and the typed expression tree above. Orchestrated
+search uses an opaque cursor over a stable global ordering; offset/page windows remain available
+only on bounded single-provider compatibility endpoints. Exact total counts are optional because
+they can be expensive, inconsistent across providers, or disclosure-sensitive.
+
 ## Security
 
 Search is a disclosure-sensitive surface because existence, counts, suggestions, facets and
@@ -240,10 +335,20 @@ Required safeguards:
 
 - Apply case/task/document authorization before returning results.
 - Apply field-level masking before returning highlights.
+- Authorize match, disclosure, aggregation, suggestion, highlight, export and semantic use as
+  separate operations; field read permission is the default prerequisite for matching.
+- Reject unknown, undeclared or unauthorized search parameters before provider execution.
 - Suppress or mask facet counts when counts would reveal hidden records.
 - Suppress suggestions that reveal unauthorized resource existence.
 - Include negative authorization tests for results, suggestions, facets and highlights.
 - Audit search activity where data classification or policy requires it.
+- Do not log raw sensitive query values; use approved redaction or keyed audit correlation.
+
+An exception that allows matching without disclosing a field requires a named policy, purpose,
+threat analysis and explicit leakage tests. Missing field decisions deny every search operation.
+For approved highly sensitive identifiers, a provider may use a keyed exact-match token instead of
+plaintext projection storage; that representation cannot support prefix, full-text, suggestion,
+facet or highlight operations.
 
 ## Operations
 
@@ -257,6 +362,14 @@ Operational requirements:
 - Explicit warnings for stale, partial or failed providers.
 - Rebuild runbooks for local projections and optional external indexes.
 - Multi-instance safe rebuild and indexing jobs, or an explicit single-instance constraint.
+- Shadow projection/index creation, backfill checkpoints, parity verification and atomic activation.
+- Rollback to the previous active profile and physical alias without rewriting case instances.
+- Privacy deletion, retention expiry and document removal propagation to every derived index.
+
+Declarative profile activation follows `draft -> validated -> approved -> materializing -> verifying
+-> active -> retired`. A failed build or verification never replaces the active profile. Materialized
+versions record the model, search profile, transformation, provider and authorization-policy
+revisions that produced them.
 
 ## Implementation Status
 
@@ -279,6 +392,11 @@ may receive a larger internal fetch window so orchestration can merge and pagina
 
 Still to implement:
 
+- Declarative model bundle, canonical field catalog and model compiler.
+- Stable search parameters, profiles, relationships and typed query expressions.
+- Permission-aware Search Descriptor and capability endpoint.
+- Cursor-based global pagination and descriptor-driven Lit search controls.
+- Governed shadow-index activation, parity verification and rollback.
 - Task/worklist provider.
 - Extracted document-text provider.
 - Timeline/comment provider.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -8,7 +8,10 @@
 > [`openapi-specs.md`](../openapi-specs.md) (the published API contract),
 > [`db-design.md`](../db-design.md) / [`db-design.sql`](../db-design.sql) (schema),
 > [`design principles.md`](../design%20principles.md) (design rationale),
-> [`search-architecture.md`](search-architecture.md) (search provider architecture).
+> [`search-architecture.md`](search-architecture.md) (search provider architecture),
+> [`declarative-case-model-architecture.md`](declarative-case-model-architecture.md) (target model
+> bundle and discovery contract), and
+> [`declarative-case-ui-proposal.md`](declarative-case-ui-proposal.md) (target presentation model).
 
 ---
 
@@ -26,7 +29,9 @@ sub-processes; the case lifecycle itself is owned by this service.
 
 **UI scope:** the backend remains the main implemented surface, but a Lit Web Components package
 now provides the standalone shell and a generic enterprise portal-adapter contract.
-Detailed product UX and form-rendering decisions remain outside this PoC.
+Detailed product UX and form-rendering decisions remain outside this PoC. The model bundle,
+server-composed View API, Search Descriptor and generic renderer are target architecture and are not
+implemented by the current runtime.
 
 ---
 
@@ -166,6 +171,10 @@ The document provider calls the Worker Permissions port before returning documen
 fails closed with an `authorization-unavailable` warning when authorization cannot be evaluated.
 Task, timeline, enterprise-reference and semantic providers are extension points. See
 [`search-architecture.md`](search-architecture.md).
+
+The target declarative contract adds stable search parameters and profiles, a permission-aware Search
+Descriptor, typed query expressions and generated projection/index plans. These remain proposed
+capabilities; current requests use the implemented provider and filter contracts described above.
 
 ---
 


### PR DESCRIPTION
## Summary

This architecture proposal defines how the platform evolves from its current declarative behavioral definition into a composable, versioned case-model bundle that drives Lit Web Component experiences and governed search.

It:
- compares client-interpreted manifests, a server-composed View API, and generated applications with a headless SDK;
- recommends a server-composed View API with a bounded view manifest and governed extension registry;
- defines a canonical case-data schema with stable field identities and a compiler-normalized field catalog;
- models commands, lifecycle, tasks, policies, events, projections, views, search, tests, and operations as independently owned bundle artifacts;
- defines stable search parameters, context-specific profiles, relationships, permission-aware Search Descriptors, and typed query expressions;
- separates search intent from generated Oracle projection and index plans, including shadow build, backfill, parity verification, activation, and rollback;
- retains the vendor-neutral embedded and standalone host model introduced by PR #86.

## Architecture review updates

Revision 4 incorporates the model-structure and discovery review:
- removes duplicate UI data schemas and makes every UI, search, event, policy, and projection reference a canonical stable field id;
- treats field discovery metadata as a policy ceiling rather than a `searchable` switch;
- distinguishes match, disclose, filter, sort, facet, suggest, highlight, export, aggregate, and semantic-use authorization;
- requires query validation before providers run and centralized projection before results reach a client;
- adds exact-match tokenization constraints for approved sensitive identifiers;
- adds caller-specific Search Descriptors and descriptor-driven Lit search controls;
- adds related-resource discovery with authorization on resources and relationship edges;
- adds independent compatibility and operational-impact assessment across data, behavior, contracts, policy, projections, physical indexes, and experience;
- preserves the prior fail-closed projection, caching, action reauthorization, extension-governance, accessibility, localization, and portal-neutrality requirements;
- corrects the current case-definition guide so it reflects implemented plan-item reference validation while explicitly identifying untyped case-variable references as the remaining gap.

## Current versus target scope

The current runtime format and implemented provider search API remain documented as current behavior. Bundle compilation, typed search expressions, the Search Descriptor endpoint, generated physical plans, the server-composed View API, and the generic renderer are explicitly marked as target architecture. No unimplemented endpoint has been added to the published OpenAPI contract.

This PR is documentation and architecture only. It does not implement the model compiler, View API, search-capability endpoint, projection activation service, renderer, or extension runtime.

## Validation

- Markdown lint: 6 changed documentation files, 0 errors.
- JSON examples: 5 parsed successfully.
- YAML examples: 5 parsed successfully.
- Mermaid: all 6 diagrams rendered successfully with Mermaid CLI.
- Documentation links: all changed files passed link checking.
- Whitespace and consistency scans: passed.
- Full Java reactor: `./mvnw test` passed on JDK 25 targeting Java 21, including Oracle and OpenAPI conformance tests.
- Web Component tests were not run: the existing `package-lock.json` contains two nested optional-package records without versions, causing both npm 10 and npm 11 installs to fail with `Invalid Version`; this PR does not modify that lockfile.
